### PR TITLE
fix: use changeset publish for proper workspace protocol resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "clean": "pnpm -r clean && rm -rf node_modules",
     "review": "node packages/cli/dist/index.js",
     "changeset": "changeset",
-    "release": "pnpm build && pnpm -r publish --access public"
+    "release": "pnpm changeset publish"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.8",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @content-reviewer/cli
+
+## 0.0.2
+
+### Patch Changes
+
+- Fix release script to use changeset publish for proper workspace protocol resolution
+- Updated dependencies
+  - @content-reviewer/core@0.0.2

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@content-reviewer/cli",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "CLI tool for reviewing written content using LLMs",
   "bin": {
     "content-review": "./dist/index.js"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @content-reviewer/core
+
+## 0.0.2
+
+### Patch Changes
+
+- Fix release script to use changeset publish for proper workspace protocol resolution

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@content-reviewer/core",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Library for reviewing written content using LLMs",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Change release script to use `pnpm changeset publish` instead of `pnpm -r publish` to properly resolve workspace:* dependencies before publishing to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)