### PR TITLE
docs: add custom instructions section and improve defaults

### DIFF
--- a/.changeset/improve-docs-and-defaults.md
+++ b/.changeset/improve-docs-and-defaults.md
@@ -1,6 +1,6 @@
 ---
-"@content-reviewer/core": patch
-"@content-reviewer/cli": patch
+'@content-reviewer/core': patch
+'@content-reviewer/cli': patch
 ---
 
 Improve default instructions with tech blog specific checks and update documentation

--- a/.changeset/improve-docs-and-defaults.md
+++ b/.changeset/improve-docs-and-defaults.md
@@ -1,0 +1,6 @@
+---
+"@content-reviewer/core": patch
+"@content-reviewer/cli": patch
+---
+
+Improve default instructions with tech blog specific checks and update documentation

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Content Reviewer
 
-An LLM-powered tool for reviewing written content. By default, it’s optimized for technical writing (e.g., blog posts, docs, guides), and you can customize it with instructions for any style or domain.
+An LLM-powered tool for reviewing written content. It comes with sensible defaults for technical writing (e.g., blog posts, docs, guides), and you can customize the review criteria to match your own standards.
 
 ## Features
 
-- Sensible defaults out of the box
-- Custom instructions for consistent, team-specific review criteria
+- Sensible defaults out of the box for technical writing
+- Customizable review criteria via instruction files
 - Structured output with severity levels (error, warning, suggestion)
 - Multiple LLM providers (OpenAI, Anthropic, Google)
 
@@ -43,21 +43,50 @@ const result = await reviewer.review({
 
 See [Core Documentation](./packages/core) for API reference.
 
+## Custom Instructions
+
+You can provide your own review criteria via an instruction file. This **replaces** the default instructions, so include everything you want checked.
+
+```bash
+content-review article.md --instruction my-standards.md
+```
+
+### Example
+
+```markdown
+## error
+
+- ...
+- Product name must be "MyProduct" (not "myproduct")
+- Code blocks must specify language
+
+## warning
+
+- ...
+- Avoid "latest version" - use exact version numbers
+
+## ignore (do NOT report)
+
+- Passive voice
+- Paragraph length
+- Minor wording suggestions
+```
+
 ## Packages
 
-| Package                                   | Description                               | Version                                                                                                             |
-| ----------------------------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| [@content-reviewer/cli](./packages/cli)   | Command-line interface for content review | [![npm](https://img.shields.io/npm/v/@content-reviewer/cli)](https://www.npmjs.com/package/@content-reviewer/cli)   |
-| [@content-reviewer/core](./packages/core) | Core library for programmatic integration | [![npm](https://img.shields.io/npm/v/@content-reviewer/core)](https://www.npmjs.com/package/@content-reviewer/core) |
+| Package                                   | Description                       | Version                                                                                                             |
+| ----------------------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| [@content-reviewer/cli](./packages/cli)   | Command-line interface            | [![npm](https://img.shields.io/npm/v/@content-reviewer/cli)](https://www.npmjs.com/package/@content-reviewer/cli)   |
+| [@content-reviewer/core](./packages/core) | Core library for programmatic use | [![npm](https://img.shields.io/npm/v/@content-reviewer/core)](https://www.npmjs.com/package/@content-reviewer/core) |
 
 ## GitHub Actions
 
-Review docs in Pull Requests with [Content Reviewer Action](https://github.com/atkei/content-reviewer-action).
+Automate reviews in Pull Requests with [Content Reviewer Action](https://github.com/atkei/content-reviewer-action).
 
 ## Prerequisites
 
 - Node.js >= 20.0.0
-- API key for a supported LLM provider (OpenAI, Anthropic, or Google)
+- API key for OpenAI, Anthropic, or Google
 
 ## Development
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -81,31 +81,18 @@ Create a `.reviewrc.json` file in your project root:
 }
 ```
 
-### Custom Instruction (Persona & Guidelines)
+### Custom Instructions
 
-You can provide an instruction file (e.g., Markdown) to define the reviewer's persona and guidelines:
+You can provide a custom instruction file to define your own review criteria:
 
 ```bash
-content-review article.md --instruction ./my-instruction.md
+content-review article.md --instruction my-standards.md
 ```
 
 Or via config file:
 
 ```json
 {
-  "instructionFile": "./my-instruction.md",
-  "language": "en"
+  "instructionFile": "./my-standards.md"
 }
-```
-
-Example instruction file:
-
-```markdown
-You are a strict technical editor.
-Please review the provided text for technical accuracy and clarity.
-
-# Review Guidelines
-
-- Ensure all code examples are correct.
-- Check for passive voice usage.
 ```

--- a/packages/core/src/default-instructions.ts
+++ b/packages/core/src/default-instructions.ts
@@ -11,9 +11,13 @@ Report each issue with the appropriate severity.
 - Exposure of sensitive information (API keys, secrets, personal data)
 - Dangerous instructions without proper warnings / safer alternatives
 - Technically incorrect or misleading statements
+- Code examples with syntax errors or incorrect API usage
 
 ## warning
 - Missing references/citations for non-obvious claims (when applicable)
+- Code examples using deprecated APIs or outdated patterns
+- Version-specific content without specifying which version
+- Missing error handling in code examples that could fail
 
 ## suggestion
 - Missing assumptions / prerequisites (OS, versions, environment, context)
@@ -21,6 +25,8 @@ Report each issue with the appropriate severity.
 - Missing scope clarification (what is covered / not covered)
 - Clarity improvements, wording refinements, optional re-structuring
 - Consistency improvements (terminology, formatting) when not misleading
+- Long paragraphs that could be broken up for readability
+- Opportunities to use active voice instead of passive voice
 `;
 
 export const DEFAULT_INSTRUCTION_JA = `あなたは技術文書に強いプロの編集者・校正者です。
@@ -36,9 +42,13 @@ export const DEFAULT_INSTRUCTION_JA = `あなたは技術文書に強いプロ�
 - APIキー・秘密情報・個人情報などの露出
 - 危険な手順（破壊的操作など）に注意書きや安全策がない
 - 技術的に誤っている／誤解を招く主張
+- コード例の文法エラーやAPIの誤用
 
 ## warning
 - 非自明な主張に根拠（参照リンク/一次情報など）が不足している（該当する場合）
+- 非推奨のAPIや古いパターンを使用したコード例
+- バージョン固有の内容でバージョンが明記されていない
+- 失敗する可能性のあるコード例にエラーハンドリングがない
 
 ## suggestion
 - 前提条件（OS/バージョン/環境/条件/対象読者など）の不足
@@ -46,4 +56,6 @@ export const DEFAULT_INSTRUCTION_JA = `あなたは技術文書に強いプロ�
 - スコープ（対象/対象外）の不明確さ
 - 表現の微調整、わかりやすさ・読みやすさ・流れの改善、任意の構成改善
 - 用語や表記の揺れなどの一貫性改善（誤解を招かない範囲）
+- 敬体（です・ます）と常体（だ・である）の混在
+- 長すぎる段落や文の分割の検討
 `;


### PR DESCRIPTION
## Summary

- Add Custom Instructions section to root README with practical example showing `...` syntax for extending defaults and `ignore` section
- Simplify CLI README custom instructions (remove verbose example, keep just usage)
- Enhance default instructions with tech blog specific checks (code syntax errors, deprecated APIs, version specificity, etc.)

## Changes

- `README.md` - Add Custom Instructions section
- `packages/cli/README.md` - Simplify custom instructions section
- `packages/core/src/default-instructions.ts` - Add tech blog specific review criteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced default review criteria with new technical-writing checks (code examples, versioning, error handling, readability/style).

* **Documentation**
  * Main README clarified defaults, added "Custom Instructions" and CLI examples; CLI docs updated examples and wording; development commands switched to pnpm.
  * Added design docs for external integrations: MCP-driven tool orchestration and web-search fact-checking (architecture, config and workflow proposals).

* **Chores**
  * Added a changeset to publish patch releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->